### PR TITLE
feat: Add liquidity now passes thorugh Violet Transaction Authorization

### DIFF
--- a/src/utils/temporary/generateEAT.ts
+++ b/src/utils/temporary/generateEAT.ts
@@ -56,3 +56,33 @@ export const getEATForMulticall = async ({
   console.log('###### Generated EAT ######: ', EAT)
   return EAT
 }
+
+export const baseUrlByEnvironment = (environment: string) => {
+  switch (environment) {
+    case 'local':
+      return 'http://localhost:8080'
+    case 'staging':
+      return 'https://staging.k8s.app.violet.co'
+    case 'development':
+      return 'https://dev.k8s.app.violet.co'
+    case 'production':
+      return 'https://app.violet.co'
+    default:
+      throw new Error('Invalid environment')
+  }
+}
+
+export const redirectUrlByEnvironment = (environment: string) => {
+  switch (environment) {
+    case 'local':
+      return 'http://localhost:3000/#/callback'
+    case 'staging':
+      return 'https://staging.k8s.app.mauve.org/#/callback'
+    case 'development':
+      return 'https://dev.k8s.app.mauve.org/#/callback'
+    case 'production':
+      return 'https://app.mauve.org/#/callback'
+    default:
+      throw new Error('Invalid environment')
+  }
+}


### PR DESCRIPTION
This Pr changes the addLiquidity functionality to use the Violet-SDK in popup mode, making the EAT generation available through the backend with the correct flows of:
- Enrollment
- Authentication
- Authorization

After an EAT is successfully generated, the Violet-SDK is able to pass the result successfully from the popup, and decode the EAT properly. 
