### PR TITLE
fix: Adds correct Dockerfile node image after migration to node 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine AS base
+FROM node:16-alpine AS base
 
 FROM base as dependencies
 


### PR DESCRIPTION
This PR changes the node base image being used on the Dockerfile, due to the migration on this repo to node version 16