### PR TITLE
fix: Removes locales from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,9 @@
 # generated contract types
 /src/types/v3
 /src/abis/types
-/src/locales/**/*.js
-/src/locales/**/en-US.po
-/src/locales/**/pseudo.po
+# /src/locales/**/*.js
+# /src/locales/**/en-US.po
+# /src/locales/**/pseudo.po
 
 # generated graphql types
 schema.graphql


### PR DESCRIPTION
HOTFIX: 

This PR removes the src/locales from the .gitignore, as part of the fix for translations not working on production environments.

A subsequent PR will be created, which will add the actual translation files on the repository