### PR TITLE
fix: Removes the .toNumber of expiry from EAT that comes from backend

### DIFF
--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -299,7 +299,7 @@ export default function AddLiquidity() {
           throw new Error('Failed to get EAT')
         }
         const { v, r, s } = eat.signature
-        calldata = await EATMulticall.encodePostsignMulticall(v, r, s, eat.expiry.toNumber(), calls)
+        calldata = await EATMulticall.encodePostsignMulticall(v, r, s, eat.expiry, calls)
       } catch (error) {
         console.error('Error generating an EAT: ', error)
       }


### PR DESCRIPTION
This PR removes the .toNumber() conversion on the expiry that is returned on the EAT from the backend.

This is necessary as authZ now returns the expiry directly as a number.