### PR TITLE
fix: Adds continue-on-error for cypress tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      continue-on-error: true
       matrix:
         containers: [1, 2, 3, 4]
     steps:


### PR DESCRIPTION
This PR moves the continue-on-error tag on the Github Action pipeline to the step level, this is due to an unknown bug where, if the tag is added on the job level, it does not have effect.