### PR TITLE
fix: [Viol-616] Upgrade base image of docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN yarn build
 ############################## nginx ##############################
 # Kubernetes build target for the release
 # nginx state for serving content
-FROM nginx:1.23.2-alpine as release
+FROM nginx:1.25.1-alpine as release
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build_kubernetes /app/build /usr/share/nginx/html
 RUN touch /var/run/nginx.pid
@@ -52,4 +52,3 @@ RUN chown -R nginx:nginx /var/run/nginx.pid /usr/share/nginx/html /var/cache/ngi
 USER nginx
 EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]
-


### PR DESCRIPTION
# Description

Upgrade base image of docker image because the previous one was flagged as having vulnerabities by AWS ECR.

## Related Issue(s)

- [VIOL-616](https://violetprotocol.atlassian.net/browse/VIOL-616)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

On Dev.

# Checklist (Pre-merge):

- [ ] My code is PO-Reviewed and is ready to be merged in addition to local tests

# Checklist (Post-merge):

- [ ] *I tested after deployment if my code works as intended on production environment*

[VIOL-616]: https://violetprotocol.atlassian.net/browse/VIOL-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ