### PR TITLE
chore: Adds aws role based access control to github actions pipeline

### DIFF
--- a/.github/workflows/ecr-build-and-push-images.yaml
+++ b/.github/workflows/ecr-build-and-push-images.yaml
@@ -34,13 +34,10 @@ on:
         required: false
         type: string
         default: eu-central-1
-    secrets:
-      PUSH_IMAGES_ECR_AWS_ACCESS_KEY_ID:
-        required: true
-      PUSH_IMAGES_ECR_AWS_SECRET_ACCESS_KEY:
-        required: true
-      PUSH_IMAGES_ECR_AWS_ACCOUNT_ID:
-        required: true
+
+permissions:
+      id-token: write   # This is required for requesting the JWT
+      contents: read    # This is required for actions/checkout
 
 jobs:
   set_environment:
@@ -95,8 +92,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1 # https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions
         with:
-          aws-access-key-id: ${{ secrets.PUSH_IMAGES_ECR_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PUSH_IMAGES_ECR_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::910202846130:role/GitHubAction-AssumeRoleWithAction
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: ${{ inputs.region }}
 
       - name: Login to Amazon ECR


### PR DESCRIPTION
# Description

This PR removes the aws-credentials user for PUSH_IMAGES in favor of role based access control, where the github runner assumes a role that has the specific permissions necessary to push new images to ECR and to access the secret manager. 


## Related Issue(s)

- VIOL-650

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Pipeline tested with PR creation, and actions passes

# Checklist (Pre-merge):

- [ ] I respected the code style (https://github.com/violetprotocol/coding-style/) and updated documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My code is PO-Reviewed and is ready to be merged in addition to local tests
- [ ] *I have merged the necessary infrastructure changes prior to merging this PR*

# Checklist (Post-merge):

- [ ] If my PR introduces new endpoints, these endpoints include strict validation of the input data
- [ ] I have notified my colleagues in discord about any necessary changes on their side
- [ ] *I tested after deployment if my code works as intended on production environment*
