### PR TITLE
fix: [VIOL-817] Removes translation from copy text that was previously breaking

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -679,7 +679,7 @@ export default function Swap({ className }: { className?: string }) {
                             </ThemedText.SubHeader>
                           ) : (
                             <ThemedText.SubHeader width="100%" textAlign="center" color="white">
-                              <Trans>Allow Mauve to use your {currencies[Field.INPUT]?.symbol}</Trans>
+                              Allow Mauve to use your {currencies[Field.INPUT]?.symbol}
                             </ThemedText.SubHeader>
                           )}
 


### PR DESCRIPTION
This PR removes the translation from the copy text that is used when a new token needs to be approved on a new wallet, setting a spending limit for swaps with mauve contracts