### PR TITLE
fix: Changes translation component to <a> due to broken text

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -691,10 +691,10 @@ export default function Swap({ className }: { className?: string }) {
                           ) : (
                             <MouseoverTooltip
                               text={
-                                <a>
+                                <p>
                                   You must give Mauve smart contracts permission to use your{' '}
                                   {currencies[Field.INPUT]?.symbol}. You only have to do this once per token.
-                                </a>
+                                </p>
                               }
                             >
                               <HelpCircle size="20" color={theme.textContrast} style={{ marginLeft: '8px' }} />


### PR DESCRIPTION
This PR removes the translation component on a text that was changed, specifically where we changed the Uniswap string for the Mauve string, so that new translations are not needed to be generated.

These changes can only be verified on the development environment, as the previous version will work normally on local environments due to the nature of how it is run locally (with a server and not statically served)