### PR TITLE
fix: Adds header to nginx config to invalidate caching

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -7,5 +7,6 @@ server {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri /index.html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
     }
 }


### PR DESCRIPTION
This PR changes the nginx server cache header configuration, asking the browser to always load the assets from the website and never cache them