### PR TITLE
fix: [VIOL-934] Adds registered badge showing conditionally

### DIFF
--- a/src/components/TransactionConfirmationModal/index.tsx
+++ b/src/components/TransactionConfirmationModal/index.tsx
@@ -208,6 +208,7 @@ function L2Content({
   hash,
   pendingText,
   inline,
+  isRegistered,
 }: {
   onDismiss: () => void
   hash: string | undefined
@@ -215,6 +216,7 @@ function L2Content({
   currencyToAdd?: Currency | undefined
   pendingText: ReactNode
   inline?: boolean // not in modal
+  isRegistered?: boolean | null
 }) {
   const theme = useTheme()
 
@@ -300,7 +302,13 @@ function L2Content({
 
           <VioletAuthorizedWrapper>
             <VioletAuthorizedColumn>
-              <VerifiedIcon /> <span>Authenticated</span>
+              {isRegistered ? (
+                <>
+                  <VerifiedIcon /> <span>Registered</span>
+                </>
+              ) : (
+                <></>
+              )}
             </VioletAuthorizedColumn>
 
             <VioletAuthorizedColumn>
@@ -359,7 +367,13 @@ export default function TransactionConfirmationModal({
       {eatPayload.status === 'authorizing' && !!authorizeProps && isRegistered ? (
         <VioletEmbeddedAuthorizationWrapper authorizeProps={authorizeProps} onIssued={onIssued} onFailed={onFailed} />
       ) : hash || attemptingTxn ? (
-        <L2Content chainId={chainId} hash={hash} onDismiss={onDismiss} pendingText={pendingText} />
+        <L2Content
+          chainId={chainId}
+          hash={hash}
+          onDismiss={onDismiss}
+          pendingText={pendingText}
+          isRegistered={isRegistered}
+        />
       ) : attemptingTxn ? (
         <ConfirmationPendingContent onDismiss={onDismiss} pendingText={pendingText} />
       ) : (

--- a/src/components/TransactionConfirmationModal/index.tsx
+++ b/src/components/TransactionConfirmationModal/index.tsx
@@ -50,9 +50,9 @@ const StyledLogo = styled.img`
   margin-left: 6px;
 `
 
-const VioletAuthorizedWrapper = styled.div`
+const VioletAuthorizedWrapper = styled.div<{ isRegistered: boolean | null | undefined }>`
   display: flex;
-  justify-content: space-between;
+  justify-content: ${(props) => (props.isRegistered ? 'space-between' : 'center')};
   align-items: center;
   width: 100%;
   padding: 8px;
@@ -300,15 +300,13 @@ function L2Content({
             )}
           </Text>
 
-          <VioletAuthorizedWrapper>
+          <VioletAuthorizedWrapper isRegistered={isRegistered}>
             <VioletAuthorizedColumn>
               {isRegistered ? (
                 <>
                   <VerifiedIcon /> <span>Registered</span>
                 </>
-              ) : (
-                <></>
-              )}
+              ) : null}
             </VioletAuthorizedColumn>
 
             <VioletAuthorizedColumn>


### PR DESCRIPTION
This PR changes the authenticated badge to be reactive and responds to wether a user is already enrolled or not with Violet;
Aditionally it also changes the wording from authenticated to "registered"