### PR TITLE
fix: Fixes discord link on error boundary

### DIFF
--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -178,7 +178,7 @@ const Fallback = ({ error, eventId }: { error: Error; eventId: string | null }) 
             <SmallButtonPrimary onClick={() => window.location.reload()}>
               <>Reload the app</>
             </SmallButtonPrimary>
-            <ExternalLink id="get-support-on-discord" href="https://discord.gg/FCfyBSbCU5" target="_blank">
+            <ExternalLink id="get-support-on-discord" href="https://discord.gg/uzt5QjNhCc" target="_blank">
               <SmallButtonLight>
                 <>Get support</>
               </SmallButtonLight>


### PR DESCRIPTION
This PR changes the discord invitation link from the error boundary to the correct one.