### PR TITLE
fix: [VIOL-988] Disable sourcemaps in deployed envs

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,6 @@
+# https://create-react-app.dev/docs/advanced-configuration
+GENERATE_SOURCEMAP=true
+
 # These API keys are intentionally public. Please do not report them - thank you for your concern.
 # REACT_APP_AMPLITUDE_PROXY_URL="https://api.uniswap.org/v1/amplitude-proxy"
 REACT_APP_AWS_API_REGION="us-east-2"

--- a/.env.k8s.example.local
+++ b/.env.k8s.example.local
@@ -1,3 +1,6 @@
+# https://create-react-app.dev/docs/advanced-configuration
+GENERATE_SOURCEMAP=true
+
 # These API keys are intentionally public. Please do not report them - thank you for your concern.
 #REACT_APP_AMPLITUDE_PROXY_URL="https://api.uniswap.org/v1/amplitude-proxy"
 REACT_APP_AWS_API_REGION="us-east-2"

--- a/.env.k8s.mauve-dev
+++ b/.env.k8s.mauve-dev
@@ -1,3 +1,6 @@
+# https://create-react-app.dev/docs/advanced-configuration
+GENERATE_SOURCEMAP=false
+
 # These API keys are intentionally public. Please do not report them - thank you for your concern.
 #REACT_APP_AMPLITUDE_PROXY_URL="https://api.uniswap.org/v1/amplitude-proxy"
 REACT_APP_AWS_API_REGION="us-east-2"

--- a/.env.k8s.mauve-prod
+++ b/.env.k8s.mauve-prod
@@ -1,3 +1,6 @@
+# https://create-react-app.dev/docs/advanced-configuration
+GENERATE_SOURCEMAP=false
+
 # These API keys are intentionally public. Please do not report them - thank you for your concern.
 #REACT_APP_AMPLITUDE_PROXY_URL="https://api.uniswap.org/v1/amplitude-proxy"
 REACT_APP_AWS_API_REGION="us-east-2"

--- a/.env.k8s.mauve-staging
+++ b/.env.k8s.mauve-staging
@@ -1,3 +1,6 @@
+# https://create-react-app.dev/docs/advanced-configuration
+GENERATE_SOURCEMAP=false
+
 # These API keys are intentionally public. Please do not report them - thank you for your concern.
 #REACT_APP_AMPLITUDE_PROXY_URL="https://api.uniswap.org/v1/amplitude-proxy"
 REACT_APP_AWS_API_REGION="us-east-2"

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,6 @@
+# https://create-react-app.dev/docs/advanced-configuration
+GENERATE_SOURCEMAP=false
+
 #REACT_APP_AMPLITUDE_PROXY_URL="https://api.uniswap.org/v1/amplitude-proxy"
 REACT_APP_AWS_API_ENDPOINT="https://api.uniswap.org/v1/graphql"
 REACT_APP_FORTMATIC_KEY="pk_live_F937DF033A1666BF"


### PR DESCRIPTION
This PR adds explicit `GENERATE_SOURCEMAP` env var to the dotenv files, and disables sourcemap generation in deployed environments.
