### PR TITLE
fix: adding correct spacings for items on navigation

### DIFF
--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -29,7 +29,7 @@ const DocsLink = styled(ExternalLink)`
   cursor: pointer;
   font-weight: 600;
   font-size: 16px;
-  padding: 10px 16px;
+  padding: 0.5rem 1rem;
 `
 
 interface MenuItemProps {

--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -81,6 +81,7 @@ const Web3StatusConnected = styled(Web3StatusGeneric)<{
 
 const AddressAndChevronContainer = styled.div`
   display: flex;
+  align-items: center;
 
   @media only screen and (max-width: ${({ theme }) => `${theme.breakpoint.lg}px`}) {
     display: none;


### PR DESCRIPTION
BEFORE
<img width="1536" alt="Screenshot 2023-09-29 at 07 11 09" src="https://github.com/violetprotocol/mauve-dex/assets/13142568/cf896af9-8da4-4538-a1bc-7e173f0589df">

AFTER
<img width="1545" alt="Screenshot 2023-09-29 at 07 11 44" src="https://github.com/violetprotocol/mauve-dex/assets/13142568/b877ba26-543d-401d-96e1-e2d360115032">
