### PR TITLE
fix: adding fix for when violet-app is not running

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,6 +224,9 @@
     "workbox-routing": "^6.1.0",
     "zustand": "^4.0.0-rc.1"
   },
+  "resolutions": {
+    "react-error-overlay": "6.0.9"
+  },
   "engines": {
     "npm": "please-use-yarn",
     "node": "16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17776,10 +17776,10 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-error-overlay@^6.0.9:
-  version "6.0.11"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
-  integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
+react-error-overlay@6.0.9, react-error-overlay@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
+  integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
 react-fast-compare@^3.0.1:
   version "3.2.2"


### PR DESCRIPTION
https://github.com/facebook/create-react-app/issues/11773#issuecomment-995933869

It seems that the issue is with hot-reloading, that has a dependency on the `react-error-overlay`, and blocks the screen because of a bug, where it doesn't find the `process` available on the window.