### PR TITLE
fix: correct error message when transaction is too old

### DIFF
--- a/src/utils/swapErrorToUserReadableMessage.tsx
+++ b/src/utils/swapErrorToUserReadableMessage.tsx
@@ -44,8 +44,10 @@ export function swapErrorToUserReadableMessage(error: any): string {
       if (reason?.indexOf('undefined is not an object') !== -1) {
         return `An error occurred when trying to execute this swap. You may need to increase your slippage tolerance. If that does not work, there may be an incompatibility with the token you are trading. Note: fee on transfer and rebase tokens are incompatible with Mauve.`
       }
-      return `Unknown error${
-        reason ? `: "${reason}"` : ''
-      }. Try increasing your slippage tolerance. Note: fee on transfer and rebase tokens are incompatible with Mauve.`
+
+      if (reason?.indexOf('Transaction too old') !== -1) {
+        return `The amount you were quoted expired. Please try again.`
+      }
+      return `Unknown error${reason ? `: "${reason}"` : ''}. Try increasing your slippage tolerance.`
   }
 }


### PR DESCRIPTION
This adds the correct error message when the "Transaction too old"